### PR TITLE
Updated Base Activity

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/base/BaseActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/base/BaseActivity.java
@@ -14,14 +14,40 @@ public abstract class BaseActivity extends AppCompatActivity {
     super.onCreate(savedInstanceState);
     setupDagger(KiwixApplication.getInstance().getApplicationComponent());
     //attachPresenter();
+    View decorView = getWindow().getDecorView();
+    decorView.setOnSystemUiVisibilityChangeListener
+            (new View.OnSystemUiVisibilityChangeListener() {
+              @Override
+              public void onSystemUiVisibilityChange(int visibility) {
+                // Note that system bars will only be "visible" if none of the
+                // LOW_PROFILE, HIDE_NAVIGATION, or FULLSCREEN flags are set.
+                if ((visibility & View.SYSTEM_UI_FLAG_FULLSCREEN) == 0) {
+                  View decorView = getWindow().getDecorView();
+// Hide both the navigation bar and the status bar.
+                  int uiOptions = View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+                          | View.SYSTEM_UI_FLAG_FULLSCREEN;
+                  decorView.setSystemUiVisibility(uiOptions);
+                } 
+              }
+            });
   }
 
   @Override protected void onStart() {
+    View decorView = getWindow().getDecorView();
+    int uiOptions = View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+            | View.SYSTEM_UI_FLAG_FULLSCREEN;
+    decorView.setSystemUiVisibility(uiOptions);
     super.onStart();
     //presenter.onStart();
   }
 
   @Override protected void onResume() {
+    // Hide Navigation Activity added in onResume() method so that whenever the app is closed via home button and then opened again
+    // then also the navigation bar remains transparent
+    View decorView = getWindow().getDecorView();
+    int uiOptions = View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+            | View.SYSTEM_UI_FLAG_FULLSCREEN;
+    decorView.setSystemUiVisibility(uiOptions);
     super.onResume();
     //presenter.onResume();
   }


### PR DESCRIPTION
In this update, the bug of overlaying of the navigation bar on greetings message at the bottom of the page is fixed by changing the transparency of navigation bar as soon as the app starts from any state.

Fixes #442

Changes: The navigation bar(available on 18:9 display phones) is made transparent and the layout is made full screen

Screenshots/GIF for the change: 
![screenshot_20180226-175436 1](https://user-images.githubusercontent.com/32356267/36670735-2cf6e6e0-1b1f-11e8-846b-a11a74502336.jpg)
